### PR TITLE
Update ValueComparer.java

### DIFF
--- a/src/main/java/edu/sustech/cs307/value/ValueComparer.java
+++ b/src/main/java/edu/sustech/cs307/value/ValueComparer.java
@@ -35,7 +35,9 @@ public class ValueComparer {
                 return Double.compare(d1, d2);
             case CHAR:
                 String s1 = (String) v1.value;
+                s1=s1.trim();
                 String s2 = (String) v2.value;
+                s2=s2.trim();
                 return s1.compareTo(s2);
             default:
                 throw new DBException(ExceptionTypes.WrongComparisonError(v1.type, v2.type));


### PR DESCRIPTION
When trying to implement Join function, we came across a situation:
If we join on INTEGER, 
we'll get a really good result.


<img width="932" alt="截屏2025-05-21 16 40 37" src="https://github.com/user-attachments/assets/059c460c-5330-4743-b2ac-9ceb823a3f03" />


But if we join on **STIRNG**, we get a blank table.


<img width="932" alt="截屏2025-05-21 16 40 17" src="https://github.com/user-attachments/assets/9c35d40c-0a10-4714-a4af-41dcd48790a4" />

After weeks of consideration, we've found that the problem lies in the ValueComparer.
When we do Type Casting for String, we simply do 
`String s1 = (String) v1.value;
 String s2 = (String) v2.value;`
,which would causes the blank of byte automatically filled by null, causing inequality of two same strings.

After we do `String.trim()`, the ordinary codes are turned into:
```
String s1 = (String) v1.value;
                s1=s1.trim();
String s2 = (String) v2.value;
                s2=s2.trim();
```
which delete all the blanks in the String, then we get our ideal result.
<img width="932" alt="截屏2025-05-21 16 41 00" src="https://github.com/user-attachments/assets/68903872-6c33-4654-9442-168222e1ad99" />

