### PR TITLE
Fix and Optimize Page Deletion Strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ bin/
 .DS_Store
 .idea/
 .CS307-DB/
+*.class
+/CS307-DB

--- a/src/main/java/edu/sustech/cs307/storage/DiskManager.java
+++ b/src/main/java/edu/sustech/cs307/storage/DiskManager.java
@@ -172,6 +172,18 @@ public class DiskManager {
         }
     }
 
+    /**
+     * 检查指定的文件是否存在。
+     * 
+     * @param filename 要检查的文件名
+     * @return 如果文件存在则返回 true，否则返回 false
+     */
+    public boolean fileExists(String filename) {
+        String real_path = currentDir + "/" + filename;
+        File file = new File(real_path);
+        return file.exists();
+    }
+
     // return file start;
     public Integer AllocatePage(String filename) throws DBException {
         Integer offset = this.filePages.get(filename);


### PR DESCRIPTION
During our development process, we encountered a bug with the following reproduction steps:

We implemented the  `dropTable`  functionality, and the core logic is as follows:

```java
dbManager.getBufferPool().DeleteAllPages(dataFileName);
dbManager.dropTable(tableName);
dbManager.getDiskManager().filePages.remove(dataFileName);
```

During testing, we found that if we create a table in the same session, insert a few rows of data into it, execute the `dropTable` command, and then create a new table with the exact same structure, the dirty data that was dropped would still reappear when queried.

After investigation, we discovered that the issue was related to the page deletion strategy. Specifically, the `DeleteAllPages` method did not properly reset the page data and metadata. The pages were not being fully invalidated after deletion, leading to the reappearance of the dirty data when a new table was created with the same name.

### Analysis of the Commit

The commit [fix: delete page strategy · xCipHanD/engine-project@ed9304a](https://github.com/xCipHanD/engine-project/commit/ed9304a0a982c7257eabe4d5be0f83b7469839a8) addresses this issue by refining the page deletion logic. Here are the key changes:

1. **Page Deletion Logic Refinement**
   - The `DeletePage` method now ensures that:
     - The page's pin count is checked before deletion. If the pin count is greater than 0, the deletion is aborted.
     - The page's dirty flag is checked. If the page is dirty, it is flushed to disk before deletion.
     - The page's data is reset to a default/invalid state after deletion to prevent data leakage.
     - The frame ID is added to the free list if it is not already present.

2. **Optimization of `FlushAllPages` Method**
   - Added a check to ensure that the file exists before attempting to flush pages. This prevents unnecessary operations and potential exceptions.
   - Wrapped the flush operation in a try-catch block to handle any potential `DBException` and ensure the dirty flag is reset even if an error occurs.

3. **Enhancement of `DeleteAllPages` Method**
   - Updated the method to directly manipulate page data and metadata:
     - The page's data is explicitly set to zero.
     - The page's dirty flag and pin count are reset.
     - The page's position is updated to an invalid state.
     - The frame ID is added to the free list if it is not already present.

4. **Utility Method for File Existence Check**
   - Added a new method `fileExists` to check if a file exists before performing operations on it. This helps in avoiding unnecessary operations and potential errors.

These changes ensure that pages are deleted safely and that the system remains in a consistent state after deletion operations. This should resolve the issue of dirty data reappearing after dropping and recreating a table.