### PR TITLE
Fix SeqScan cross-page RID calculation bug

### DIFF
--- a/src/main/java/edu/sustech/cs307/physicalOperator/SeqScanOperator.java
+++ b/src/main/java/edu/sustech/cs307/physicalOperator/SeqScanOperator.java
@@ -21,6 +21,7 @@ public class SeqScanOperator implements PhysicalOperator {
     private TableMeta tableMeta;
     private RecordFileHandle fileHandle;
     private Record currentRecord;
+    private RID currentRID;
 
     private int currentPageNum;
     private int currentSlotNum;
@@ -85,21 +86,23 @@ public class SeqScanOperator implements PhysicalOperator {
             return;
         try {
             if (hasNext()) { // Advance to the next record
-                RID rid = new RID(currentPageNum, currentSlotNum);
-                currentRecord = fileHandle.GetRecord(rid);
+                currentRID = new RID(currentPageNum, currentSlotNum);
+                currentRecord = fileHandle.GetRecord(currentRID);
                 currentSlotNum++;
                 if (currentSlotNum >= recordsPerPage) {
                     currentPageNum++;
                     currentSlotNum = 0;
                 }
                 // readonly
-                fileHandle.UnpinPageHandle(currentPageNum, false);
+                fileHandle.UnpinPageHandle(currentRID.pageNum, false);
             } else {
                 currentRecord = null;
+                currentRID = null;
             }
         } catch (DBException e) {
             e.printStackTrace(); // Handle exception properly
             currentRecord = null;
+            currentRID = null;
         }
     }
 
@@ -108,7 +111,7 @@ public class SeqScanOperator implements PhysicalOperator {
         if (!isOpen || currentRecord == null) {
             return null;
         }
-        return new TableTuple(tableName, tableMeta, currentRecord, new RID(this.currentPageNum, this.currentSlotNum - 1));
+        return new TableTuple(tableName, tableMeta, currentRecord, currentRID);
     }
 
     @Override
@@ -122,6 +125,7 @@ public class SeqScanOperator implements PhysicalOperator {
         }
         fileHandle = null;
         currentRecord = null;
+        currentRID = null;
         isOpen = false;
     }
 


### PR DESCRIPTION
Next() 在递增 slotNum 后可能发生翻页，而 Current() 通过 (currentPageNum, currentSlotNum - 1) 反推 RID。翻页后 currentSlotNum = 0，slotNum - 1 = -1，导致对每页最后一条记录执行 delete 或 update 时触发 IndexOutOfBoundsException 。同时修复了 UnpinPageHandle 在翻页后使用了翻页后的页号（下一页），而非实际读取的页号。
修复方式：
在 Next() 翻页前将 RID 保存为 currentRID ，Current() 直接使用该 RID，不再通过指针反推。